### PR TITLE
Add PDF Creation Github Action

### DIFF
--- a/.github/workflows/create_pdfs.yaml
+++ b/.github/workflows/create_pdfs.yaml
@@ -1,0 +1,40 @@
+name: Create PDFs from reports
+
+on: push
+
+jobs:
+  create_pdfs:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: get changed reports
+        id: get_changed_files
+        run: |
+          files=$(git diff $CI_COMMIT_BEFORE_SHA $GI_COMMIT_SHA --name-only --diff-filter=d -- '***.md' '***.csv' '***.tsv');
+          echo "files=${files//$'\n'/' '}" > $GITHUB_OUTPUT;
+        env:
+          CI_COMMIT_BEFORE_SHA: ${{ github.event.before }}
+          GI_COMMIT_SHA: ${{ github.event.after }}
+      - name: convert
+        if: steps.get_changed_files.outputs.files
+        uses: docker://pandoc/latex:3
+        with:
+          entrypoint: /bin/sh
+          args: >-
+            -c
+            "
+            for report in ${{ steps.get_changed_files.outputs.files }};
+            do
+              pandoc -o \"${report%.*}.pdf\" $report;
+            done;
+            "
+      - name: commit
+        if: steps.get_changed_files.outputs.files
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: '***.pdf'
+          message: 'autogen pdfs'
+      


### PR DESCRIPTION
Add a PDF Creation GitHub Action


Unfortunately, Actions are notoriously hard to auto-test, so I don't have automated tests for this. You can copy it - at its path - to any descendent repository, and see how it works.


It is currently configured to listen for new or changed `.md`, `.tsv`, and `.csv` files to turn into PDFs since the last upload, each push.


Please also determine/decide if generating a commit online is bothersome for e.g. merging reasons - there are some alternative delivery methods, such as Github Artifacts, or alternative cadences such as on a Version Tag that are possible without too much trouble.