### PR TITLE
Fix issue with python version and pydantic 1.x in <1.10.0 folio_migration_tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 description = "Template project for FOLIO migrations using FOLIO-FSE/folio_migration_tools"
 authors = [{name = "Your Name", email = "you@example.com"}]
 readme = "README.md"
-requires-python = ">=3.13,<4.0"
+requires-python = ">=3.13,<3.14"
 dependencies = [
     "dotenv>=0.9.9",
-    "folio-data-import>=0.3.2,<0.4.0",
+    "folio-data-import>=0.3.2,<0.5.0",
     "folio-migration-tools>=1.9.6,<2.0.0",
     "ipykernel>=6.30.1",
     "jupyter>=1.1.1",


### PR DESCRIPTION
Previous PR introduced an issue where uv would set up a virtual environment with python 3.14, while the maximum version of pydantic compaitble with folio_migration_tools was <2.0, which incompatible with python 3.14. While we wait for a pydantic 2.0+ compatible version of folio_migration_tools, we're going to cap python version at 3.13.x.