### PR TITLE
Update Python version requirement and remove explicit dependency on folio-data-import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,10 @@ version = "0.1.0"
 description = "Template project for FOLIO migrations using FOLIO-FSE/folio_migration_tools"
 authors = [{name = "Your Name", email = "you@example.com"}]
 readme = "README.md"
-requires-python = ">=3.13,<3.14"
+requires-python = ">=3.13,<3.15"
 dependencies = [
     "dotenv>=0.9.9",
-    "folio-data-import>=0.3.2,<0.5.0",
-    "folio-migration-tools>=1.9.6,<2.0.0",
+    "folio-migration-tools>=1.10.3,<2.0.0",
     "ipykernel>=6.30.1",
     "jupyter>=1.1.1",
     "pandas>=2.3.2,<3.0.0",


### PR DESCRIPTION
- `folio-data-import` dependency is now managed by `folio-migration-tools`
- Tools now support Pi-thon, so this adjusts the `requires-python` to include it